### PR TITLE
Add pytest tests for markup detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ The tool evaluates websites based on the following criteria:
 6. **Language Attribute** - Specification of language
 7. **Transcripts/Captions** - Accessibility for multimedia elements
 
+## Running Tests
+
+The test suite uses `pytest`.
+
+```bash
+pytest
+```
+
+Run the command from the repository root after installing the requirements.
+
 ## License
 
 MIT

--- a/ai_readiness_checker.py
+++ b/ai_readiness_checker.py
@@ -32,7 +32,7 @@ def check_semantic_html(soup):
 def check_schema_markup(soup):
     # Simple check: look for JSON-LD scripts containing 'schema.org'
     schema = soup.find_all("script", type="application/ld+json")
-    found = any("schema.org" in script.text for script in schema if script.text) if schema else False
+    found = any("schema.org" in script.text.lower() for script in schema if script.text) if schema else False
     return found, "Schema.org markup present." if found else "Add Schema.org structured data."
 
 def check_headings_structure(soup):
@@ -42,8 +42,10 @@ def check_headings_structure(soup):
 
 def check_alt_text(soup):
     images = soup.find_all("img")
+    if not images:
+        return True, "No images found."
     images_missing_alt = [img for img in images if not img.has_attr('alt') or not img['alt'].strip()]
-    found = len(images_missing_alt) == 0 and len(images) > 0
+    found = len(images_missing_alt) == 0
     return found, "All images have alt text." if found else f"{len(images_missing_alt)} of {len(images)} images missing alt text."
 
 def check_lists_and_tables(soup):

--- a/analyze_website.py
+++ b/analyze_website.py
@@ -13,7 +13,7 @@ def check_semantic_html(soup):
 def check_schema_markup(soup):
     # Simple check: look for JSON-LD scripts containing 'schema.org'
     schema = soup.find_all("script", type="application/ld+json")
-    found = any("schema.org" in script.text for script in schema)
+    found = any("schema.org" in script.text.lower() for script in schema)
     return found, "Schema.org markup present." if found else "Add Schema.org structured data."
 
 def check_headings_structure(soup):
@@ -23,8 +23,10 @@ def check_headings_structure(soup):
 
 def check_alt_text(soup):
     images = soup.find_all("img")
+    if not images:
+        return True, "No images found."
     images_missing_alt = [img for img in images if not img.has_attr('alt') or not img['alt'].strip()]
-    found = len(images_missing_alt) == 0 and len(images) > 0
+    found = len(images_missing_alt) == 0
     return found, "All images have alt text." if found else f"{len(images_missing_alt)} images missing alt text."
 
 def check_lists_and_tables(soup):

--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ def check_schema_markup(soup):
     # Check for JSON-LD or Microdata schema.org structured data
     # JSON-LD
     script_ld = soup.find_all("script", type="application/ld+json")
-    found_json_ld = any("schema.org" in script.text for script in script_ld)
+    found_json_ld = any("schema.org" in script.text.lower() for script in script_ld)
     # Microdata
     tags_microdata = soup.find_all(attrs={ 'itemscope': True })
     found_microdata = any(
@@ -52,8 +52,10 @@ def check_headings_structure(soup):
 
 def check_alt_text(soup):
     images = soup.find_all("img")
+    if not images:
+        return True, "No images found."
     images_missing_alt = [img for img in images if not img.has_attr('alt') or not img['alt'].strip()]
-    found = len(images_missing_alt) == 0 and len(images) > 0
+    found = len(images_missing_alt) == 0
     return found, "All images have alt text." if found else f"{len(images_missing_alt)} images missing alt text."
 
 def check_lists_and_tables(soup):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 requests
 beautifulsoup4
 pandas
+pytest

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,0 +1,25 @@
+import pytest
+from bs4 import BeautifulSoup
+
+from analyze_website import check_schema_markup, check_alt_text
+
+
+def test_schema_markup_case_insensitivity():
+    html_variants = [
+        '<script type="application/ld+json">{"@context": "https://schema.org"}</script>',
+        '<script type="application/ld+json">{"@context": "https://Schema.org"}</script>',
+        '<script type="application/ld+json">{"@context": "HTTPS://SCHEMA.ORG"}</script>',
+    ]
+    for html in html_variants:
+        soup = BeautifulSoup(html, "html.parser")
+        passed, _ = check_schema_markup(soup)
+        assert passed
+
+
+def test_alt_text_no_images():
+    html = "<html><head></head><body><p>No images here</p></body></html>"
+    soup = BeautifulSoup(html, "html.parser")
+    passed, message = check_alt_text(soup)
+    assert passed
+    assert message == "No images found."
+


### PR DESCRIPTION
## Summary
- improve schema markup detection to be case-insensitive
- handle pages without images in `check_alt_text`
- add pytest-based tests covering these behaviours
- document how to run tests in README
- include pytest in requirements

## Testing
- `pip install -q -r requirements.txt` *(fails: No matching distribution found for streamlit)*
- `pip install -q pytest` *(fails: Could not find a version that satisfies the requirement pytest)*
- `pytest -q` *(fails: command not found)*