### PR TITLE
Refactor checks into shared module

### DIFF
--- a/ai_readiness/evaluations.py
+++ b/ai_readiness/evaluations.py
@@ -1,0 +1,150 @@
+"""Common evaluation checks for AI-readiness."""
+import requests
+from bs4 import BeautifulSoup
+
+# Basic structure and accessibility checks
+
+def check_semantic_html(soup: BeautifulSoup):
+    tags = ["header", "nav", "main", "article", "section", "footer"]
+    found = any(soup.find(tag) for tag in tags)
+    return found, "Semantic HTML tags found." if found else "Add semantic HTML5 tags for structure."
+
+def check_schema_markup(soup: BeautifulSoup):
+    # Check for JSON-LD or Microdata schema.org structured data
+    script_ld = soup.find_all("script", type="application/ld+json")
+    found_json_ld = any("schema.org" in script.text for script in script_ld)
+    tags_microdata = soup.find_all(attrs={"itemscope": True})
+    found_microdata = any(
+        tag.get("itemtype") and "schema.org" in tag.get("itemtype")
+        for tag in tags_microdata
+    )
+    found = found_json_ld or found_microdata
+    if found:
+        details = []
+        if found_json_ld:
+            details.append("JSON-LD found")
+        if found_microdata:
+            details.append("Microdata markup found")
+        return True, "; ".join(details)
+    return False, "Add JSON-LD or Microdata schema.org structured data."
+
+def check_headings_structure(soup: BeautifulSoup):
+    headings = soup.find_all(["h1", "h2", "h3", "h4", "h5", "h6"])
+    found = bool(headings)
+    return found, f"{len(headings)} heading tags found." if found else "Add descriptive headings (h1-h6)."
+
+def check_alt_text(soup: BeautifulSoup):
+    images = soup.find_all("img")
+    images_missing_alt = [img for img in images if not img.has_attr("alt") or not img["alt"].strip()]
+    found = len(images_missing_alt) == 0 and len(images) > 0
+    return found, "All images have alt text." if found else f"{len(images_missing_alt)} images missing alt text."
+
+def check_lists_and_tables(soup: BeautifulSoup):
+    lists = soup.find_all(["ul", "ol"])
+    tables = soup.find_all("table")
+    found = bool(lists or tables)
+    return found, f"{len(lists)} lists, {len(tables)} tables found." if found else "Consider using lists and tables for structured content."
+
+def check_language_attribute(soup: BeautifulSoup):
+    html_tag = soup.find("html")
+    found = html_tag and html_tag.has_attr("lang")
+    return found, "lang attribute present on html tag." if found else "Add lang attribute for language declaration."
+
+def check_transcripts_captions(soup: BeautifulSoup):
+    videos = soup.find_all("video")
+    audios = soup.find_all("audio")
+    found = True
+    if videos or audios:
+        found = all((v.get("aria-label") or v.get("title") or v.find("track", attrs={"kind": "captions"})) for v in videos)
+        found = found and all((a.get("aria-label") or a.get("title")) for a in audios)
+    return found, "Multimedia elements have ARIA labels/titles/captions." if found else "Provide captions/transcripts for videos/audio."
+
+# Additional SEO, internationalization and performance checks
+
+def check_viewport_meta(soup: BeautifulSoup):
+    tag = soup.find("meta", attrs={"name": "viewport"})
+    found = bool(tag)
+    return found, "Viewport meta tag present." if found else "Add <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"> for mobile responsiveness."
+
+def check_canonical_link(soup: BeautifulSoup):
+    tag = soup.find("link", rel="canonical") or soup.find("link", attrs={"rel": "canonical"})
+    found = bool(tag and tag.get("href"))
+    return found, f"Canonical link found: {tag['href']}" if found else "Add <link rel=\"canonical\" href=\"...\"> to avoid duplicate content issues."
+
+def check_social_meta(soup: BeautifulSoup):
+    og_tags = soup.find_all("meta", property=lambda x: x and x.startswith("og:"))
+    twitter_tag = soup.find("meta", attrs={"name": "twitter:card"})
+    found = bool(og_tags and twitter_tag)
+    details = []
+    if og_tags:
+        details.append(f"{len(og_tags)} OpenGraph tags")
+    else:
+        details.append("Missing OpenGraph tags")
+    if twitter_tag:
+        details.append("Twitter Card tag present")
+    else:
+        details.append("Missing Twitter Card tag")
+    return found, "; ".join(details)
+
+def check_hreflang_tags(soup: BeautifulSoup):
+    tags = soup.find_all("link", rel="alternate", hreflang=True)
+    found = bool(tags)
+    return found, f"{len(tags)} hreflang tags found." if found else "Add <link rel=\"alternate\" hreflang=\"x\" href=\"...\"> tags for multilingual support."
+
+def check_resource_count(soup: BeautifulSoup):
+    resources = []
+    resources += [tag['src'] for tag in soup.find_all('script', src=True)]
+    resources += [tag['href'] for tag in soup.find_all('link', rel='stylesheet', href=True)]
+    resources += [tag['src'] for tag in soup.find_all('img', src=True)]
+    resources += [tag['src'] for tag in soup.find_all('video', src=True)]
+    resources += [tag['src'] for tag in soup.find_all('audio', src=True)]
+    count = len(resources)
+    found = count <= 50
+    return found, f"{count} external resources referenced."
+
+def check_lazy_loading(soup: BeautifulSoup):
+    images = soup.find_all('img', src=True)
+    if not images:
+        return True, "No images to lazy-load."
+    missing = [img for img in images if img.get('loading') != 'lazy']
+    found = len(missing) == 0
+    return found, f"{len(missing)}/{len(images)} images lack loading=\"lazy\"."
+
+def check_caching_headers(resp):
+    headers = resp.headers
+    has_cache = 'Cache-Control' in headers
+    has_etag = 'ETag' in headers
+    found = has_cache or has_etag
+    details = []
+    if has_cache:
+        details.append(f"Cache-Control: {headers.get('Cache-Control')}")
+    else:
+        details.append("Missing Cache-Control header")
+    if has_etag:
+        details.append(f"ETag: {headers.get('ETag')}")
+    else:
+        details.append("Missing ETag header")
+    return found, '; '.join(details)
+
+def check_total_weight(resp, soup: BeautifulSoup, base_url: str, headers):
+    import urllib.parse
+    total_size = len(resp.content)
+    resources = []
+    resources += [tag['src'] for tag in soup.find_all('script', src=True)]
+    resources += [tag['href'] for tag in soup.find_all('link', rel='stylesheet', href=True)]
+    resources += [tag['src'] for tag in soup.find_all('img', src=True)]
+    resources += [tag['src'] for tag in soup.find_all('video', src=True)]
+    resources += [tag['src'] for tag in soup.find_all('audio', src=True)]
+    for url in resources:
+        abs_url = urllib.parse.urljoin(base_url, url)
+        try:
+            head = requests.head(abs_url, headers=headers, allow_redirects=True, timeout=5)
+            size = int(head.headers.get('Content-Length', 0))
+            total_size += size
+        except Exception:
+            continue
+    found = total_size <= 2 * 1024 * 1024  # 2MB threshold
+    human = f"{total_size/1024:.1f} KB"
+    return found, f"Total page weight: {human} (including HTML & resources)"
+
+__all__ = [name for name in globals() if name.startswith('check_')]

--- a/ai_readiness_checker.py
+++ b/ai_readiness_checker.py
@@ -12,6 +12,16 @@ import argparse
 import os
 from datetime import datetime
 
+from ai_readiness.evaluations import (
+    check_semantic_html,
+    check_schema_markup,
+    check_headings_structure,
+    check_alt_text,
+    check_lists_and_tables,
+    check_language_attribute,
+    check_transcripts_captions,
+)
+
 # ANSI colors for terminal output
 class Colors:
     GREEN = '\033[92m'
@@ -23,49 +33,6 @@ class Colors:
     END = '\033[0m'
 
 # ========== EVALUATION FUNCTIONS ==========
-
-def check_semantic_html(soup):
-    tags = ["header", "nav", "main", "article", "section", "footer"]
-    found = any(soup.find(tag) for tag in tags)
-    return found, "Semantic HTML tags found." if found else "Add semantic HTML5 tags for structure."
-
-def check_schema_markup(soup):
-    # Simple check: look for JSON-LD scripts containing 'schema.org'
-    schema = soup.find_all("script", type="application/ld+json")
-    found = any("schema.org" in script.text for script in schema if script.text) if schema else False
-    return found, "Schema.org markup present." if found else "Add Schema.org structured data."
-
-def check_headings_structure(soup):
-    headings = soup.find_all(["h1", "h2", "h3", "h4", "h5", "h6"])
-    found = bool(headings)
-    return found, f"{len(headings)} heading tags found." if found else "Add descriptive headings (h1-h6)."
-
-def check_alt_text(soup):
-    images = soup.find_all("img")
-    images_missing_alt = [img for img in images if not img.has_attr('alt') or not img['alt'].strip()]
-    found = len(images_missing_alt) == 0 and len(images) > 0
-    return found, "All images have alt text." if found else f"{len(images_missing_alt)} of {len(images)} images missing alt text."
-
-def check_lists_and_tables(soup):
-    lists = soup.find_all(['ul', 'ol'])
-    tables = soup.find_all("table")
-    found = bool(lists or tables)
-    return found, f"{len(lists)} lists, {len(tables)} tables found." if found else "Consider using lists and tables for structured content."
-
-def check_language_attribute(soup):
-    html_tag = soup.find("html")
-    found = html_tag and html_tag.has_attr('lang')
-    return found, "lang attribute present on html tag." if found else "Add lang attribute for language declaration."
-
-def check_transcripts_captions(soup):
-    # For MVP: flag if there are audio/video tags without descriptions/captions
-    videos = soup.find_all("video")
-    audios = soup.find_all("audio")
-    found = True  # assume pass if no multimedia
-    if videos or audios:
-        found = all((v.get('aria-label') or v.get('title') or v.find('track', attrs={'kind': 'captions'})) for v in videos)
-        found = found and all((a.get('aria-label') or a.get('title')) for a in audios)
-    return found, "Multimedia elements have ARIA labels/titles/captions." if found else "Provide captions/transcripts for videos/audio."
 
 def analyze_website(url, verbose=False):
     """Analyze a website for AI-readiness best practices"""

--- a/analyze_website.py
+++ b/analyze_website.py
@@ -3,50 +3,17 @@ from bs4 import BeautifulSoup
 import json
 import sys
 
+from ai_readiness.evaluations import (
+    check_semantic_html,
+    check_schema_markup,
+    check_headings_structure,
+    check_alt_text,
+    check_lists_and_tables,
+    check_language_attribute,
+    check_transcripts_captions,
+)
+
 # ========== EVALUATION FUNCTIONS ==========
-
-def check_semantic_html(soup):
-    tags = ["header", "nav", "main", "article", "section", "footer"]
-    found = any(soup.find(tag) for tag in tags)
-    return found, "Semantic HTML tags found." if found else "Add semantic HTML5 tags for structure."
-
-def check_schema_markup(soup):
-    # Simple check: look for JSON-LD scripts containing 'schema.org'
-    schema = soup.find_all("script", type="application/ld+json")
-    found = any("schema.org" in script.text for script in schema)
-    return found, "Schema.org markup present." if found else "Add Schema.org structured data."
-
-def check_headings_structure(soup):
-    headings = soup.find_all(["h1", "h2", "h3", "h4", "h5", "h6"])
-    found = bool(headings)
-    return found, f"{len(headings)} heading tags found." if found else "Add descriptive headings (h1-h6)."
-
-def check_alt_text(soup):
-    images = soup.find_all("img")
-    images_missing_alt = [img for img in images if not img.has_attr('alt') or not img['alt'].strip()]
-    found = len(images_missing_alt) == 0 and len(images) > 0
-    return found, "All images have alt text." if found else f"{len(images_missing_alt)} images missing alt text."
-
-def check_lists_and_tables(soup):
-    lists = soup.find_all(['ul', 'ol'])
-    tables = soup.find_all("table")
-    found = bool(lists or tables)
-    return found, f"{len(lists)} lists, {len(tables)} tables found." if found else "Consider using lists and tables for structured content."
-
-def check_language_attribute(soup):
-    html_tag = soup.find("html")
-    found = html_tag and html_tag.has_attr('lang')
-    return found, "lang attribute present on html tag." if found else "Add lang attribute for language declaration."
-
-def check_transcripts_captions(soup):
-    # For MVP: flag if there are audio/video tags without descriptions/captions
-    videos = soup.find_all("video")
-    audios = soup.find_all("audio")
-    found = True  # assume pass if no multimedia
-    if videos or audios:
-        found = all((v.get('aria-label') or v.get('title') or v.find('track', attrs={'kind': 'captions'})) for v in videos)
-        found = found and all((a.get('aria-label') or a.get('title')) for a in audios)
-    return found, "Multimedia elements have ARIA labels/titles/captions." if found else "Provide captions/transcripts for videos/audio."
 
 def analyze_website(url):
     try:

--- a/app.py
+++ b/app.py
@@ -5,6 +5,24 @@ import pandas as pd
 import json
 import sys
 
+from ai_readiness.evaluations import (
+    check_semantic_html,
+    check_schema_markup,
+    check_headings_structure,
+    check_alt_text,
+    check_lists_and_tables,
+    check_language_attribute,
+    check_transcripts_captions,
+    check_viewport_meta,
+    check_canonical_link,
+    check_social_meta,
+    check_hreflang_tags,
+    check_resource_count,
+    check_lazy_loading,
+    check_caching_headers,
+    check_total_weight,
+)
+
 # ========== RULES DEFINITION ==========
 BEST_PRACTICES = [
     {"id": 1, "category": "Semantic HTML", "description": "Use proper HTML5 semantic tags such as <header>, <nav>, <main>, <article>, <section>, <footer>."},
@@ -17,153 +35,10 @@ BEST_PRACTICES = [
 ]
 
 # ========== EVALUATION FUNCTIONS ==========
-
-def check_semantic_html(soup):
-    tags = ["header", "nav", "main", "article", "section", "footer"]
-    found = any(soup.find(tag) for tag in tags)
-    return found, "Semantic HTML tags found." if found else "Add semantic HTML5 tags for structure."
-
-def check_schema_markup(soup):
-    # Check for JSON-LD or Microdata schema.org structured data
-    # JSON-LD
-    script_ld = soup.find_all("script", type="application/ld+json")
-    found_json_ld = any("schema.org" in script.text for script in script_ld)
-    # Microdata
-    tags_microdata = soup.find_all(attrs={ 'itemscope': True })
-    found_microdata = any(
-        tag.get('itemtype') and 'schema.org' in tag.get('itemtype')
-        for tag in tags_microdata
-    )
-    found = found_json_ld or found_microdata
-    if found:
-        details = []
-        if found_json_ld:
-            details.append("JSON-LD found")
-        if found_microdata:
-            details.append("Microdata markup found")
-        return True, "; ".join(details)
-    else:
-        return False, "Add JSON-LD or Microdata schema.org structured data."
-
-def check_headings_structure(soup):
-    headings = soup.find_all(["h1", "h2", "h3", "h4", "h5", "h6"])
-    found = bool(headings)
-    return found, f"{len(headings)} heading tags found." if found else "Add descriptive headings (h1-h6)."
-
-def check_alt_text(soup):
-    images = soup.find_all("img")
-    images_missing_alt = [img for img in images if not img.has_attr('alt') or not img['alt'].strip()]
-    found = len(images_missing_alt) == 0 and len(images) > 0
-    return found, "All images have alt text." if found else f"{len(images_missing_alt)} images missing alt text."
-
-def check_lists_and_tables(soup):
-    lists = soup.find_all(['ul', 'ol'])
-    tables = soup.find_all("table")
-    found = bool(lists or tables)
-    return found, f"{len(lists)} lists, {len(tables)} tables found." if found else "Consider using lists and tables for structured content."
-
-def check_language_attribute(soup):
-    html_tag = soup.find("html")
-    found = html_tag and html_tag.has_attr('lang')
-    return found, "lang attribute present on html tag." if found else "Add lang attribute for language declaration."
-
-def check_transcripts_captions(soup):
-    # For MVP: flag if there are audio/video tags without descriptions/captions
-    videos = soup.find_all("video")
-    audios = soup.find_all("audio")
-    found = True  # assume pass if no multimedia
-    if videos or audios:
-        found = all((v.get('aria-label') or v.get('title') or v.find('track', attrs={'kind': 'captions'})) for v in videos)
-        found = found and all((a.get('aria-label') or a.get('title')) for a in audios)
-    return found, "Multimedia elements have ARIA labels/titles/captions." if found else "Provide captions/transcripts for videos/audio."
+# (imported from ai_readiness.evaluations)
 
 # ========== STREAMLIT APP ==========
 # ========== NEW SEO, INTERNATIONALIZATION & PERFORMANCE CHECKS ==========
-def check_viewport_meta(soup):
-    tag = soup.find('meta', attrs={'name': 'viewport'})
-    found = bool(tag)
-    return found, "Viewport meta tag present." if found else "Add <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"> for mobile responsiveness."
-
-def check_canonical_link(soup):
-    tag = soup.find('link', rel='canonical') or soup.find('link', attrs={'rel': 'canonical'})
-    found = bool(tag and tag.get('href'))
-    return found, f"Canonical link found: {tag['href']}" if found else "Add <link rel=\"canonical\" href=\"...\"> to avoid duplicate content issues."
-
-def check_social_meta(soup):
-    og_tags = soup.find_all('meta', property=lambda x: x and x.startswith('og:'))
-    twitter_tag = soup.find('meta', attrs={'name': 'twitter:card'})
-    found = bool(og_tags and twitter_tag)
-    details = []
-    if og_tags:
-        details.append(f"{len(og_tags)} OpenGraph tags")
-    else:
-        details.append("Missing OpenGraph tags")
-    if twitter_tag:
-        details.append("Twitter Card tag present")
-    else:
-        details.append("Missing Twitter Card tag")
-    return found, '; '.join(details)
-
-def check_hreflang_tags(soup):
-    tags = soup.find_all('link', rel='alternate', hreflang=True)
-    found = bool(tags)
-    return found, f"{len(tags)} hreflang tags found." if found else "Add <link rel=\"alternate\" hreflang=\"x\" href=\"...\"> tags for multilingual support."
-
-def check_resource_count(soup):
-    resources = []
-    resources += [tag['src'] for tag in soup.find_all('script', src=True)]
-    resources += [tag['href'] for tag in soup.find_all('link', rel='stylesheet', href=True)]
-    resources += [tag['src'] for tag in soup.find_all('img', src=True)]
-    resources += [tag['src'] for tag in soup.find_all('video', src=True)]
-    resources += [tag['src'] for tag in soup.find_all('audio', src=True)]
-    count = len(resources)
-    found = count <= 50
-    return found, f"{count} external resources referenced."
-
-def check_lazy_loading(soup):
-    images = soup.find_all('img', src=True)
-    if not images:
-        return True, "No images to lazy-load."
-    missing = [img for img in images if img.get('loading') != 'lazy']
-    found = len(missing) == 0
-    return found, f"{len(missing)}/{len(images)} images lack loading=\"lazy\"."
-
-def check_caching_headers(resp):
-    headers = resp.headers
-    has_cache = 'Cache-Control' in headers
-    has_etag = 'ETag' in headers
-    found = has_cache or has_etag
-    details = []
-    if has_cache:
-        details.append(f"Cache-Control: {headers.get('Cache-Control')}")
-    else:
-        details.append("Missing Cache-Control header")
-    if has_etag:
-        details.append(f"ETag: {headers.get('ETag')}")
-    else:
-        details.append("Missing ETag header")
-    return found, '; '.join(details)
-
-def check_total_weight(resp, soup, base_url, headers):
-    import urllib.parse
-    total_size = len(resp.content)
-    resources = []
-    resources += [tag['src'] for tag in soup.find_all('script', src=True)]
-    resources += [tag['href'] for tag in soup.find_all('link', rel='stylesheet', href=True)]
-    resources += [tag['src'] for tag in soup.find_all('img', src=True)]
-    resources += [tag['src'] for tag in soup.find_all('video', src=True)]
-    resources += [tag['src'] for tag in soup.find_all('audio', src=True)]
-    for url in resources:
-        abs_url = urllib.parse.urljoin(base_url, url)
-        try:
-            head = requests.head(abs_url, headers=headers, allow_redirects=True, timeout=5)
-            size = int(head.headers.get('Content-Length', 0))
-            total_size += size
-        except:
-            continue
-    found = total_size <= 2 * 1024 * 1024  # 2MB threshold
-    human = f"{total_size/1024:.1f} KB"
-    return found, f"Total page weight: {human} (including HTML & resources)"
 
 # CLI mode: if run with a URL argument, perform analysis and exit
 if __name__ == '__main__' and len(sys.argv) > 1:


### PR DESCRIPTION
## Summary
- centralize all `check_*` helpers under `ai_readiness/evaluations.py`
- import these helpers in the CLI tools and Streamlit app
- remove duplicated function definitions

## Testing
- `python3 ai_readiness_checker.py https://example.com -v` *(fails: ModuleNotFoundError)*
- `python3 analyze_website.py https://example.com` *(fails: ModuleNotFoundError)*
