### PR TITLE
Add basic pytest suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,12 @@ The tool evaluates websites based on the following criteria:
 ## License
 
 MIT
+
+## Running Tests
+
+Install pytest and run:
+```bash
+pip install pytest
+pytest
+```
+

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,57 @@
+from bs4 import BeautifulSoup
+import ai_readiness_checker as arc
+
+
+def make_soup(html: str) -> BeautifulSoup:
+    return BeautifulSoup(html, 'html.parser')
+
+
+def test_check_semantic_html():
+    good = make_soup('<header></header><main></main>')
+    bad = make_soup('<div></div>')
+    assert arc.check_semantic_html(good)[0] is True
+    assert arc.check_semantic_html(bad)[0] is False
+
+
+def test_check_schema_markup():
+    html = '<script type="application/ld+json">{"@context":"schema.org"}</script>'
+    soup = make_soup(html)
+    missing = make_soup('<script></script>')
+    assert arc.check_schema_markup(soup)[0] is True
+    assert arc.check_schema_markup(missing)[0] is False
+
+
+def test_check_headings_structure():
+    soup = make_soup('<h1>Title</h1>')
+    empty = make_soup('<div></div>')
+    assert arc.check_headings_structure(soup)[0] is True
+    assert arc.check_headings_structure(empty)[0] is False
+
+
+def test_check_alt_text():
+    soup = make_soup('<img alt="test"/>')
+    bad = make_soup('<img/>')
+    assert arc.check_alt_text(soup)[0] is True
+    assert arc.check_alt_text(bad)[0] is False
+
+
+def test_check_lists_and_tables():
+    soup = make_soup('<ul><li>A</li></ul>')
+    bad = make_soup('<div></div>')
+    assert arc.check_lists_and_tables(soup)[0] is True
+    assert arc.check_lists_and_tables(bad)[0] is False
+
+
+def test_check_language_attribute():
+    soup = make_soup('<html lang="en"></html>')
+    bad = make_soup('<html></html>')
+    assert arc.check_language_attribute(soup)[0] is True
+    assert arc.check_language_attribute(bad)[0] is False
+
+
+def test_check_transcripts_captions():
+    html = '<video aria-label="v"></video><audio aria-label="a"></audio>'
+    soup = make_soup(html)
+    bad = make_soup('<video></video>')
+    assert arc.check_transcripts_captions(soup)[0] is True
+    assert arc.check_transcripts_captions(bad)[0] is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,32 @@
+import json
+import subprocess
+import sys
+import threading
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+
+def start_server(html: str):
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html')
+            self.end_headers()
+            self.wfile.write(html.encode())
+
+    server = HTTPServer(('localhost', 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, server.server_address[1]
+
+
+def test_cli(tmp_path):
+    html = '<html><header></header><h1>Test</h1></html>'
+    server, port = start_server(html)
+    out_file = tmp_path / 'result.json'
+    cmd = [sys.executable, 'ai_readiness_checker.py', f'http://localhost:{port}', '-o', str(out_file)]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    server.shutdown()
+    assert result.returncode == 0
+    data = json.loads(out_file.read_text())
+    assert data['url'] == f'http://localhost:{port}'
+    assert data['total'] == 7


### PR DESCRIPTION
## Summary
- add pytest-based unit tests for HTML checks
- add CLI test using a local HTTP server
- document how to run the tests in the README

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*