### PR TITLE
Fix schema.org detection case sensitivity

### DIFF
--- a/ai_readiness_checker.py
+++ b/ai_readiness_checker.py
@@ -32,7 +32,11 @@ def check_semantic_html(soup):
 def check_schema_markup(soup):
     # Simple check: look for JSON-LD scripts containing 'schema.org'
     schema = soup.find_all("script", type="application/ld+json")
-    found = any("schema.org" in script.text for script in schema if script.text) if schema else False
+    found = any(
+        "schema.org" in script.text.lower()
+        for script in schema
+        if script.text
+    ) if schema else False
     return found, "Schema.org markup present." if found else "Add Schema.org structured data."
 
 def check_headings_structure(soup):

--- a/analyze_website.py
+++ b/analyze_website.py
@@ -13,7 +13,11 @@ def check_semantic_html(soup):
 def check_schema_markup(soup):
     # Simple check: look for JSON-LD scripts containing 'schema.org'
     schema = soup.find_all("script", type="application/ld+json")
-    found = any("schema.org" in script.text for script in schema)
+    found = any(
+        "schema.org" in script.text.lower()
+        for script in schema
+        if script.text
+    )
     return found, "Schema.org markup present." if found else "Add Schema.org structured data."
 
 def check_headings_structure(soup):

--- a/app.py
+++ b/app.py
@@ -27,7 +27,10 @@ def check_schema_markup(soup):
     # Check for JSON-LD or Microdata schema.org structured data
     # JSON-LD
     script_ld = soup.find_all("script", type="application/ld+json")
-    found_json_ld = any("schema.org" in script.text for script in script_ld)
+    found_json_ld = any(
+        "schema.org" in (script.text or "").lower()
+        for script in script_ld
+    )
     # Microdata
     tags_microdata = soup.find_all(attrs={ 'itemscope': True })
     found_microdata = any(

--- a/tests/test_schema_markup.py
+++ b/tests/test_schema_markup.py
@@ -1,0 +1,69 @@
+import importlib
+import sys
+import types
+import unittest
+
+# Create dummy dependencies for modules
+class Dummy:
+    def __call__(self, *args, **kwargs):
+        return self
+    def __getattr__(self, name):
+        return self
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+dummy_streamlit = Dummy()
+sys.modules.setdefault('streamlit', dummy_streamlit)
+sys.modules.setdefault('requests', types.ModuleType('requests'))
+bs4_module = types.ModuleType('bs4')
+bs4_module.BeautifulSoup = lambda *args, **kwargs: None
+sys.modules.setdefault('bs4', bs4_module)
+sys.modules.setdefault('pandas', types.ModuleType('pandas'))
+
+ai_checker = importlib.import_module('ai_readiness_checker')
+analyze = importlib.import_module('analyze_website')
+app = importlib.import_module('app')
+
+class DummyTag:
+    def __init__(self, text=None, attrs=None):
+        self.text = text
+        self.attrs = attrs or {}
+    def get(self, key, default=None):
+        return self.attrs.get(key, default)
+
+class DummySoup:
+    def __init__(self, scripts=None, micro=None):
+        self._scripts = scripts or []
+        self._micro = micro or []
+    def find_all(self, name=None, type=None, attrs=None):
+        if name == "script" and type == "application/ld+json":
+            return self._scripts
+        if attrs == {"itemscope": True}:
+            return self._micro
+        return []
+
+class SchemaMarkupTests(unittest.TestCase):
+    def test_ai_checker_jsonld_mixed_case(self):
+        soup = DummySoup([DummyTag('{"@context": "https://Schema.org"}')])
+        found, _ = ai_checker.check_schema_markup(soup)
+        self.assertTrue(found)
+
+    def test_analyze_website_jsonld_mixed_case(self):
+        soup = DummySoup([DummyTag('{"@context": "HTTP://SCHEMA.ORG"}')])
+        found, _ = analyze.check_schema_markup(soup)
+        self.assertTrue(found)
+
+    def test_app_jsonld_and_microdata(self):
+        soup = DummySoup(
+            [DummyTag('{"@context": "https://schema.ORg"}')],
+            [DummyTag(attrs={'itemtype': 'https://schema.org/Article'})]
+        )
+        found, details = app.check_schema_markup(soup)
+        self.assertTrue(found)
+        self.assertIn("JSON-LD", details)
+        self.assertIn("Microdata", details)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- update schema detection to use lowercase JSON-LD scripts
- keep microdata logic the same
- add tests for mixed-case `Schema.org`

## Testing
- `python -m unittest discover -s tests -p 'test*.py' -v`
